### PR TITLE
fix(polars): align struct field order between output builder and sche…

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           working-directory: polars_order_book
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels

--- a/polars_order_book/.github/workflows/publish_to_pypi.yml
+++ b/polars_order_book/.github/workflows/publish_to_pypi.yml
@@ -62,7 +62,7 @@ jobs:
           
           target: ${{ matrix.target }}
           
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -90,7 +90,7 @@ jobs:
           
           target: ${{ matrix.target }}
           
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -114,7 +114,7 @@ jobs:
           
           target: ${{ matrix.target }}
           
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/polars_order_book/src/calculate_bbo.rs
+++ b/polars_order_book/src/calculate_bbo.rs
@@ -410,12 +410,12 @@ mod tests {
             "qty" => [10i64, 20, 30, 40, 50, 90, 80, 70, 60],
             "is_bid" => [true, true, true, true, true, false, false, false, false],
             "bid_price_1" => [1i64, 2, 3, 4, 5, 5, 5, 5, 5],
-            "bid_price_2" => [None, Some(1i64), Some(2), Some(3), Some(4), Some(4), Some(4), Some(4), Some(4)],
             "bid_qty_1" => [10i64, 20, 30, 40, 50, 50, 50, 50, 50],
-            "bid_qty_2" => [None, Some(10i64), Some(20), Some(30), Some(40), Some(40), Some(40), Some(40), Some(40)],
             "ask_price_1" => [None, None, None, None, None, Some(9i64), Some(8), Some(7), Some(6)],
-            "ask_price_2" => [None, None, None, None, None, None, Some(9i64), Some(8), Some(7)],
             "ask_qty_1" => [None, None, None, None, None, Some(90i64), Some(80), Some(70), Some(60)],
+            "bid_price_2" => [None, Some(1i64), Some(2), Some(3), Some(4), Some(4), Some(4), Some(4), Some(4)],
+            "bid_qty_2" => [None, Some(10i64), Some(20), Some(30), Some(40), Some(40), Some(40), Some(40), Some(40)],
+            "ask_price_2" => [None, None, None, None, None, None, Some(9i64), Some(8), Some(7)],
             "ask_qty_2" => [None, None, None, None, None, None, Some(90i64), Some(80), Some(70)],
         }
         .unwrap();
@@ -467,11 +467,12 @@ mod tests {
             "prev_price" => [None, Some(1i64), Some(2), Some(3), Some(4), None, Some(9), Some(8), Some(7), Some(5), Some(6)],
             "prev_qty" => [None, Some(10i64), Some(20), Some(30), Some(40), None, Some(90), Some(80), Some(70), Some(50), Some(60)],
             "bid_price_1" => [1i64, 2, 3, 4, 5, 5, 5, 5, 5, 1, 1],
-            "bid_price_2" => [Option::<i64>::None, None, None, None, None, None, None, None, None, None, None],            "bid_qty_1" => [10i64, 20, 30, 40, 50, 50, 50, 50, 50, 1, 1],
-            "bid_qty_2" => [Option::<i64>::None, None, None, None, None, None, None, None, None, None, None],
+            "bid_qty_1" => [10i64, 20, 30, 40, 50, 50, 50, 50, 50, 1, 1],
             "ask_price_1" => [None, None, None, None, None, Some(9i64), Some(8), Some(7), Some(6), Some(6), Some(9)],
-            "ask_price_2" => [Option::<i64>::None, None, None, None, None, None, None, None, None, None, None],
             "ask_qty_1" => [None, None, None, None, None, Some(90i64), Some(80), Some(70), Some(60), Some(60), Some(1)],
+            "bid_price_2" => [Option::<i64>::None, None, None, None, None, None, None, None, None, None, None],
+            "bid_qty_2" => [Option::<i64>::None, None, None, None, None, None, None, None, None, None, None],
+            "ask_price_2" => [Option::<i64>::None, None, None, None, None, None, None, None, None, None, None],
             "ask_qty_2" => [Option::<i64>::None, None, None, None, None, None, None, None, None, None, None],
             }
             .unwrap();
@@ -522,12 +523,12 @@ mod tests {
             "prev_price" => vec![None, None, Some(1), Some(2), Some(3), Some(6), Some(5), Some(4)],
             "prev_qty" => vec![None, None, Some(1), Some(2), Some(3), Some(6), Some(5), Some(4)],
             "bid_price_1" => vec![1, 1, 2, 3, 1, 1, 1, 1],
-            "bid_price_2" => vec![Option::<i64>::None, None, None, None, None, None, None, None],
             "bid_qty_1" => vec![1, 1, 2, 3, 1, 1, 1, 1],
-            "bid_qty_2" => vec![Option::<i64>::None, None, None, None, None, None, None, None],
             "ask_price_1" => vec![None, Some(6), Some(6), Some(6), Some(6), Some(5), Some(4), Some(6)],
-            "ask_price_2" => vec![Option::<i64>::None, None, None, None, None, None, None, None],
             "ask_qty_1" => vec![None, Some(6), Some(6), Some(6), Some(6), Some(5), Some(4), Some(6)],
+            "bid_price_2" => vec![Option::<i64>::None, None, None, None, None, None, None, None],
+            "bid_qty_2" => vec![Option::<i64>::None, None, None, None, None, None, None, None],
+            "ask_price_2" => vec![Option::<i64>::None, None, None, None, None, None, None, None],
             "ask_qty_2" => vec![Option::<i64>::None, None, None, None, None, None, None, None],
         }.unwrap();
 

--- a/polars_order_book/src/output.rs
+++ b/polars_order_book/src/output.rs
@@ -87,14 +87,19 @@ impl<'a, const N: usize> OutputBuilder<TopNLevelsOutput<'a, N>> for TopNLevelsDa
     }
 
     fn finish(self) -> PolarsResult<DataFrame> {
-        let columns = self
+        let mut columns = Vec::with_capacity(4 * N);
+        for (((bp, bq), ap), aq) in self
             .bid_prices
             .into_iter()
-            .chain(self.bid_qtys)
-            .chain(self.ask_prices)
-            .chain(self.ask_qtys)
-            .map(|builder| builder.finish().into_column())
-            .collect();
+            .zip(self.bid_qtys)
+            .zip(self.ask_prices)
+            .zip(self.ask_qtys)
+        {
+            columns.push(bp.finish().into_column());
+            columns.push(bq.finish().into_column());
+            columns.push(ap.finish().into_column());
+            columns.push(aq.finish().into_column());
+        }
         DataFrame::new(columns)
     }
 }


### PR DESCRIPTION
…ma declaration

The TopNLevelsDataframeBuilder::finish() produced columns grouped by field type (all bid_prices, then all bid_qtys, ...) while bbo_struct declared them interleaved per level (bid_price_1, bid_qty_1, ask_price_1, ask_qty_1, bid_price_2, ...). This mismatch caused non-deterministic struct field ordering when used with .over(), as Polars reconciled the declared schema against the actual data differently across groups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the column ordering of the generated `bbo` struct for top-N levels, which can affect downstream code that relied on the previous (incorrect) field order. CI build workflow tweaks are low risk but could change wheel build behavior across platforms.
> 
> **Overview**
> Fixes a schema mismatch in `TopNLevelsDataframeBuilder::finish()` by emitting columns *interleaved per level* (`bid_price_i`, `bid_qty_i`, `ask_price_i`, `ask_qty_i`) instead of grouped by type, preventing non-deterministic struct field ordering in Polars operations like `.over()`.
> 
> Updates BBO calculation tests to reflect the new deterministic column order, and removes `--find-interpreter` from `maturin` wheel builds in the PyPI publish GitHub workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 258ce202727e6bd968038948459afcb322687d3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->